### PR TITLE
Implemented 8-bit cells

### DIFF
--- a/src/Brainfuck.php
+++ b/src/Brainfuck.php
@@ -65,8 +65,8 @@
                 if ($char === '>') $pointer++;
                 if ($char === '<') $pointer--;
                 if (!isset($cells[$pointer])) $cells[$pointer] = 0;
-                if ($char === '+') $cells[$pointer]++;
-                if ($char === '-') $cells[$pointer]--;
+                if ($char === '+') $cells[$pointer] = self::_truemod($cells[$pointer] + 1, 256);
+                if ($char === '-') $cells[$pointer] = self::_truemod($cells[$pointer] - 1, 256);
                 if ($char === '.') $result .= chr($cells[$pointer]);
                 if ($char === ']') {
                     $close_pos = $p;
@@ -261,4 +261,7 @@
             return $text;
         }
 
+        private static function _truemod($num, $mod) {
+            return ($mod + ($num % $mod)) % $mod;
+        }
     }


### PR DESCRIPTION
This honors values to stay within the 8-bit range of 0-256. This is the default for Brainfuck.

PHP's Modulo isn't a "true" modulo as it does not wrap negative values. Because if that I introduced a custom mod function.

The following script (which made use of going "negative") didn't work and now does:
```
-[------->+<]>+++.+[--->+<]>.------------.--.--[--->+<]>-.-----------.----.
```